### PR TITLE
chore(docker): upgrade Go base — 1.21-alpine → 1.26-alpine3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.26-alpine3.22 as builder
+FROM golang:1.21-alpine as builder
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache gcc musl-dev linux-headers git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.26-alpine3.22 as builder
 
-RUN apk add --no-cache gcc musl-dev linux-headers git
+RUN apk upgrade --no-cache && \
+    apk add --no-cache gcc musl-dev linux-headers git
 
 # Get dependencies - will also be cached if we won't change go.mod/go.sum
 COPY go.mod /go-ethereum/
@@ -17,9 +18,10 @@ ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 
 # Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.26-alpine3.22 as builder
+FROM golang:1.21-alpine as builder
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache gcc musl-dev linux-headers git

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,9 +4,10 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.21-alpine as builder
+FROM golang:1.26-alpine3.22 as builder
 
-RUN apk add --no-cache gcc musl-dev linux-headers git
+RUN apk upgrade --no-cache && \
+    apk add --no-cache gcc musl-dev linux-headers git
 
 # Get dependencies - will also be cached if we won't change go.mod/go.sum
 COPY go.mod /go-ethereum/
@@ -17,9 +18,10 @@ ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install -static
 
 # Pull all binaries into a second stage deploy alpine container
-FROM alpine:latest
+FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp


### PR DESCRIPTION
## Summary
- \`golang:1.21-alpine\` → \`golang:1.26-alpine3.22\` in both \`Dockerfile\` and \`Dockerfile.alltools\`. Go 1.21 and 1.22 are EOL; 1.25 and 1.26 are the only currently-supported lines.
- \`alpine:latest\` → \`alpine:3.22\` (pin for reproducibility).
- Adds \`apk upgrade --no-cache\` before each \`apk add\` to pick up fresh package manifests.

## Context
This repo's CLAUDE.md already declares "Go version: 1.22+ (toolchain 1.23.1)" but the Dockerfiles were still on 1.21-alpine. Bumping to 1.26 aligns with the current stable and eliminates the CVE exposure from the EOL 1.21 line.

## Test plan
- [ ] CircleCI build + unit-test + lint pipelines pass
- [ ] \`make geth\` / \`make all\` still work
- [ ] \`go run build/ci.go test -tags=ckzg,integrationtests\` passes

🤖 _This response was generated by Claude Code._