### PR TITLE
chore: bump golang-jwt/jwt/v4 to v4.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
 	github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46
 	github.com/gofrs/flock v0.8.1
-	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb
 	github.com/google/gofuzz v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
## Summary
- Bumps `github.com/golang-jwt/jwt/v4` from **v4.5.0 → v4.5.2**
- Clears Docker Scout HIGH **CVE-2025-30204** (Asymmetric Resource Consumption / Amplification, CVSS 8.7)

## Why this one only
This is the only fixable Scout-flagged dependency that compiles under the **Go 1.22.0** toolchain cap (memory: blst v0.3.11 fails on Go ≥ 1.22.1, so the rollup-op-geth builder is pinned to `golang:1.22.0-alpine`). The other fixable highs in the image — `google.golang.org/grpc`, `go.opentelemetry.io/otel/sdk`, `golang.org/x/crypto`, `github.com/consensys/gnark-crypto` — all require Go ≥ 1.23.0 in their patched releases, so they're blocked behind the blst bump.

`v4.5.2` only requires Go 1.16, so no toolchain change.

## Scout impact (paired with rome-rollup-clients PR for non-root user)
| | Before | After local rebuild |
|---|---|---|
| Vulnerabilities | 5C / 35H / 43M / 3L | 4C / 22H / 34M / 2L |
| Fixable | 5C / 30H | 4C / 21H |

(The bigger sweep is the `apk upgrade` rebuild + non-root USER directive in the companion PR; this PR specifically removes the JWT high.)

## Test plan
- [x] `go get github.com/golang-jwt/jwt/v4@v4.5.2` ran cleanly inside `golang:1.22.0-alpine` (same builder image CI uses)
- [x] `docker build` against this branch produced a working image
- [x] Geth boot + JSON-RPC roundtrip verified locally
- [ ] CI `build_and_test_wf.yml` green

🤖 _This response was generated by Claude Code._