### PR TITLE
chore: add Dependabot config + auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Sourced from: rome-protocol/rome-ops/templates/dependabot/go.yml
+# Rome's OP Stack geth fork — Go modules + Docker + GitHub Actions
+
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - go
+    groups:
+      gomod-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+    ignore:
+      # blst >= 0.3.12 breaks Go 1.22.0. rollup-op-geth builder is capped
+      # at Go 1.22.0 until upstream op-geth bumps blst.
+      - dependency-name: "github.com/supranational/blst"
+        versions: [">= 0.3.12"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      gh-actions:
+        update-types:
+          - patch
+          - minor
+          - major
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+# Sourced from: rome-protocol/rome-ops/templates/dependabot/dependabot-auto-merge.yml
+#
+# Phase 2: auto-merge patch + minor for github_actions, cargo, npm, pip, gomod.
+# Docker stays manual indefinitely (nginx:1.30-alpine-slim curl regression precedent).
+# Major version bumps across all ecosystems still queue for human review.
+#
+# Security note: PR_URL is sourced from `github.event.pull_request.html_url`,
+# which is GitHub-generated (not user-controlled), routed through env: with
+# quoted "$PR_URL" expansion — no direct ${{ }} interpolation in run:.
+
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for low-risk updates
+        if: |
+          (steps.meta.outputs.package-ecosystem == 'github_actions' ||
+           steps.meta.outputs.package-ecosystem == 'cargo' ||
+           steps.meta.outputs.package-ecosystem == 'npm_and_yarn' ||
+           steps.meta.outputs.package-ecosystem == 'pip' ||
+           steps.meta.outputs.package-ecosystem == 'gomod') &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor')
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Adds .github/dependabot.yml + .github/workflows/dependabot-auto-merge.yml from rome-ops templates.

Go modules + Docker + GitHub Actions. blst >= 0.3.12 ignored (Go 1.22 cap).

🤖 _This response was generated by Claude Code._