### PR TITLE
ci: add dependabot-build job so dep PRs get verified

### DIFF
--- a/.github/workflows/build_and_test_wf.yml
+++ b/.github/workflows/build_and_test_wf.yml
@@ -25,7 +25,38 @@ env:
   OP_GETH_REF_NAME: ${{ github.ref_name }}
 
 jobs:
+  # Dependabot PRs run with a restricted secrets scope (only secrets.dependabot.*),
+  # so they cannot read OP_GETH_CROSS_REPO_APP_PRIVATE_KEY. Without that the
+  # cross-repo dispatch step below fails immediately, and the run-tests job
+  # gated on it skips — leaving every dependabot PR with red CI and zero
+  # actual verification of the bumped dependency.
+  #
+  # This job runs in-repo `go build` + `go vet` for dependabot PRs as a
+  # proof-of-life gate. It catches the cases dependabot bumps actually break:
+  # module resolution, API drift in std-lib bumps, and the blst-vs-Go-version
+  # incompat (blst >= 0.3.12 fails on Go >= 1.22.1) that hits whenever a
+  # transitive bump pulls a newer Go std lib. Image build + downstream
+  # integration tests still happen on every non-dependabot push via
+  # build-image / run-tests.
+  #
+  # github.actor is a GitHub-controlled identity string, not user input —
+  # safe to use directly in if: conditions.
+  dependabot-build:
+    if: github.actor == 'dependabot[bot]'
+    name: Dependabot build check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: go build
+        run: go build ./...
+      - name: go vet
+        run: go vet ./...
+
   build-image:
+    if: github.actor != 'dependabot[bot]'
     name: Dispatch rome-rollup-clients image build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why
All 6 open dependabot PRs (#79, #80, #81, #82, #83, #84) are failing CI at the **same step** — \`Dispatch rome-rollup-clients image build\` — within ~5 seconds with:

\`\`\`
Error: Input required and not supplied: private-key
\`\`\`

The dispatch step uses \`actions/create-github-app-token@v1\` with \`secrets.OP_GETH_CROSS_REPO_APP_PRIVATE_KEY\`. Dependabot PRs run with a restricted secrets scope (only \`secrets.dependabot.*\` is available), so the App private key is missing, dispatch fails, and the \`run-tests\` job gated on it skips — leaving every dependabot PR with red CI and zero verification of the bumped dep.

## What
Adds a \`dependabot-build\` job that runs **only** on \`github.actor == 'dependabot[bot]'\` and exercises \`go build ./...\` + \`go vet ./...\` directly in op-geth. This catches the cases dependabot bumps actually break:
- module resolution / transitive dep range conflicts
- API drift in std-lib bumps
- the blst-vs-Go-version pin (blst >=0.3.12 fails on Go >=1.22.1) that bites whenever a transitive bump pulls a newer Go std lib

The existing \`build-image\` / \`run-tests\` flow is gated to non-dependabot actors, so cross-repo image builds + downstream integration tests continue to run on every human push and on main pushes.

## Effect on the 6 open dependabot PRs
After this lands, dependabot needs to either rebase its PRs or be retriggered for the new workflow to apply. Expected outcome:
- Bumps that are clean compile (e.g. otel/sdk, hashicorp/go-retryablehttp) → green
- Bumps that pull blst-blocking newer Go std libs → red, surfacing the real compat issue cleanly instead of the spurious dispatch error

## Security note
\`github.actor\` is a GitHub-controlled identity string (not user input), safe to use directly in \`if:\` conditions per the workflow-injection guide.

🤖 _This response was generated by Claude Code._