### PR TITLE
ci: pin dependabot-build to Go 1.22.0 to honor blst pin

### DIFF
--- a/.github/workflows/build_and_test_wf.yml
+++ b/.github/workflows/build_and_test_wf.yml
@@ -49,10 +49,22 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          # Pin Go 1.22.0 explicitly. setup-go with `go-version-file: go.mod`
+          # honors go.mod's `toolchain go1.23.1` directive over the `go 1.22.0`
+          # line, but blst v0.3.11 (the pinned crypto lib) can't compile under
+          # Go >=1.22.1 — the "cannot define new methods on non-local type"
+          # rule tightened. Until upstream op-geth bumps blst, every build
+          # must run on exactly 1.22.0.
+          go-version: '1.22.0'
       - name: go build
+        env:
+          # Disable Go's auto-toolchain switch so the `toolchain` directive
+          # in go.mod can't pull a newer Go at build time.
+          GOTOOLCHAIN: local
         run: go build ./...
       - name: go vet
+        env:
+          GOTOOLCHAIN: local
         run: go vet ./...
 
   build-image:


### PR DESCRIPTION
## Why
Follow-up to #87. After #87 merged, the rebased dependabot PRs (#79–#84) all surfaced the same blst compile failure on the new \`Dependabot build check\` job:

\`\`\`
../../../go/pkg/mod/github.com/supranational/blst@v0.3.11/bindings/go/blst.go:207:11:
  cannot define new methods on non-local type SecretKey
\`\`\`

Per CLAUDE.md (\"Go 1.22.0 compat\") and project memory (\"op-geth Go version capped at 1.22.0 by blst — blst v0.3.11 breaks on Go >= 1.22.1\"), the build must run on exactly Go 1.22.0 until upstream op-geth bumps blst.

The first cut of \`dependabot-build\` used \`go-version-file: go.mod\`, which \`setup-go\` interprets as the **\`toolchain go1.23.1\`** directive (newer) rather than the \`go 1.22.0\` line. So CI got 1.23.1 → blst broke → all 6 dependabot PRs re-failed cleanly but for a now-known reason.

## What
- Pin \`go-version: '1.22.0'\` explicitly so setup-go never auto-bumps from the toolchain directive
- Set \`GOTOOLCHAIN: local\` on the build/vet steps so Go itself can't auto-fetch a newer toolchain at build time

## Effect on the 6 dependabot PRs
After this lands and the PRs are re-rebased, expected outcome:
- Pure-Go bumps that are clean on 1.22.0 → green ✅
- Bumps that pull a transitive Go std-lib requirement >1.22.0 → red, surfacing the real blst-blocker on the bumped dep specifically (not the workflow infrastructure)

## Test plan
- [x] Valid YAML
- [ ] Verify on a rebased dependabot PR that \`Dependabot build check\` selects Go 1.22.0 and either compiles cleanly or fails with the actual transitive issue (not the toolchain-1.23.1 issue)

🤖 _This response was generated by Claude Code._