### PR TITLE
ci: ignore blst-blocked deps in dependabot until upstream bumps blst

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,16 @@ updates:
       # at Go 1.22.0 until upstream op-geth bumps blst.
       - dependency-name: "github.com/supranational/blst"
         versions: [">= 0.3.12"]
+      # The following deps' newer versions force go.mod's Go directive to
+      # >= 1.23 / 1.24 / 1.25, which can't compile against blst v0.3.11
+      # (Go 1.22.0 ceiling). Confirmed empirically against PRs #79, #80,
+      # #81, #82, #84 — each errored with `go: go.mod requires go >= X`.
+      # Re-evaluate when the blst pin above lifts.
+      - dependency-name: "google.golang.org/grpc"
+      - dependency-name: "github.com/consensys/gnark-crypto"
+      - dependency-name: "go.opentelemetry.io/otel/sdk"
+      - dependency-name: "golang.org/x/crypto"
+      - dependency-name: "golang.org/x/net"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Why
After #87 + #88 + #89 wired up the \`dependabot-build\` job to actually verify dep bumps, 5 of the 6 open dependabot PRs surfaced a clear pattern:

| PR | Dep | Forces Go to |
|---|---|---|
| #79 | grpc 1.79.3 | >= 1.24.0 |
| #80 | gnark-crypto 0.18 | >= 1.23.0 |
| #81 | otel/sdk 1.43 | >= 1.25.0 |
| #82 | x/crypto 0.45 | >= 1.24.0 |
| #84 | x/net 0.38 | >= 1.23.0 |

All 5 are blst-blocked: blst v0.3.11 only compiles on Go 1.22.0, so any dep bump that pulls a newer Go std-lib requirement is unmergeable until upstream op-geth bumps blst.

Without ignore rules, dependabot will reopen these 5 PRs every Friday cycle and they'll all fail the new \`Dependabot build check\` for the same reason — pure noise.

## What
Adds 5 \`dependency-name\` entries to the existing gomod \`ignore\` block alongside blst. Patterned after the existing blst ignore.

## When to revert
When upstream op-geth bumps blst (lifting the Go 1.22.0 ceiling), drop these ignore lines and let dependabot reopen the bumps naturally.

## Side effect
The 5 currently-open PRs (#79, #80, #81, #82, #84) will be closed in a follow-up commit referencing this PR's rationale. PR #83 (go-retryablehttp 0.7.7) was already merged because it's the only one that doesn't bump Go.

🤖 _This response was generated by Claude Code._