### PR TITLE
docs: Rome-context line atop the upstream README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Part of [Rome Protocol](https://github.com/rome-protocol)** — EVM chains that run natively inside the Solana runtime. This fork is . For building on Rome, start at the [Rome Protocol Documentation](https://docs.rome.builders).
+
 ## Go Ethereum
 
 Official Golang execution layer implementation of the Ethereum protocol.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Part of [Rome Protocol](https://github.com/rome-protocol)** — EVM chains that run natively inside the Solana runtime. This fork is . For building on Rome, start at the [Rome Protocol Documentation](https://docs.rome.builders).
+> **Part of [Rome Protocol](https://github.com/rome-protocol)** — EVM chains that run natively inside the Solana runtime. This fork is the op-geth client Rome uses for Ethereum RPC compatibility. For building on Rome, start at the [Rome Protocol Documentation](https://docs.rome.builders).
 
 ## Go Ethereum
 


### PR DESCRIPTION
Fleet-audit fix: this fork's README was pure upstream with zero Rome context. Adds one line at the top saying what the fork is for in Rome's stack + links to the org and docs. No other changes.